### PR TITLE
remove bit-invert from ftoi.c/ftoi_func.vhd

### DIFF
--- a/ftoi.c
+++ b/ftoi.c
@@ -3,22 +3,6 @@
 #include <stdlib.h>
 #include "def.h"
 
-uint32_t bit_invert(uint32_t a) {
-  uint32_t result = 0;
-  uint32_t temp;
-  int flag; // 0 or 1;
-  int nflag; // 反転させたもの
-  int i;
-  for (i = 0; i < 32; i++) {
-    temp = a >> (31 - i);
-    flag = temp & 1;
-    nflag = 1 - flag;
-    result = result + (nflag << (31 - i));
-  }
-  return (result);
-}
-
-
 uint32_t ftrc(uint32_t a) {
   union data_32bit a_32bit;
   uint32_t result;
@@ -35,22 +19,22 @@ uint32_t ftrc(uint32_t a) {
     diff = a_32bit.exp - 127;
     if (diff > 30) {
       if (flag == 0) {
-	result = INT_MAX;
+        result = INT_MAX;
       } else {
-	result = NINT_MAX;
+        result = NINT_MAX;
       }
     } else {
       if (diff < 23) {
-	n = diff;
-	nbit = a_32bit.frac >> (23 - n);
+        n = diff;
+        nbit = a_32bit.frac >> (23 - n);
       } else {
-	n = 23;
-	nbit = a_32bit.frac;
+        n = 23;
+        nbit = a_32bit.frac;
       }
       result = (1 << diff) + (nbit << (diff - n));
     }
     if (flag == 1) {
-      result = bit_invert(result) + 1;    
+      result = -result;
     }
   }
   return (result);

--- a/ftoi_func.vhd
+++ b/ftoi_func.vhd
@@ -13,37 +13,15 @@ end package;
 
 package body ftoi_p is
 
-  function bit_invert(a: fpu_data_t)
-    return fpu_data_t is
-
-    variable result: fpu_data_t := (others => '0');
-    variable temp: fpu_data_t;
-    variable flag: fpu_data_t;
-    variable nflag: fpu_data_t;
-    variable i: integer range 0 to 31;
-
-  begin
-
-    for i in 0 to 31 loop
-      temp := shift_right(a, 31-i);
-      flag := temp and x"00000001";
-      nflag := x"00000001" - flag;
-      result := result + shift_left(nflag, 31-i);
-    end loop;
-
-    return result;
-
-  end function;
-
   function ftoi(a: fpu_data_t)
     return fpu_data_t is
 
-    variable a_32bit: float_t;
-    variable result: fpu_data_t;
-    variable flag: fpu_data_t;
-    variable diff: integer range 0 to 128;
-    variable nbit: fpu_data_t;
-    variable n: integer range 0 to 23;
+    variable a_32bit : float_t;
+    variable result  : fpu_data_t;
+    variable flag    : fpu_data_t;
+    variable diff    : integer range 0 to 128;
+    variable nbit    : fpu_data_t;
+    variable n       : integer range 0 to 23;
 
   begin
 
@@ -77,7 +55,7 @@ package body ftoi_p is
                   shift_left(nbit, diff - n);
       end if;
       if flag = 1 then
-        result := bit_invert(result) + 1;
+        result := (not result) + 1;
       end if;
     end if;
 


### PR DESCRIPTION
bit-invertをよく見たらlogical notだったので置き換えました。結果としてftoiのクリティカルパスが短かくなりました。
